### PR TITLE
Ensure full Context is set during Open, Save, New File, Change Document.

### DIFF
--- a/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
@@ -58,7 +58,7 @@ class SceneOperation(HookClass):
                                 - save_file_as
                                 - version_up
 
-        :param file_version:    The version/revision of the file to be opened. 
+        :param file_version:    The version/revision of the file to be opened.
                                 If this is 'None' then the latest version
                                 should be opened.
 
@@ -68,11 +68,12 @@ class SceneOperation(HookClass):
         :returns:               Depends on operation:
                                 'current_path' - Return the current scene
                                                  file path as a String
-                                'reset'        - True if scene was reset to an 
+                                'reset'        - True if scene was reset to an
                                                  empty state, otherwise False
                                 all others     - None
         """
         app = self.parent
+        engine = app.engine
 
         app.log_debug("-" * 50)
         app.log_debug("operation: %s" % operation)
@@ -84,8 +85,13 @@ class SceneOperation(HookClass):
 
         doc = c4d.documents.GetActiveDocument()
 
+        if operation in ['open', 'save', 'save_as']:
+            # Store the full Shotgun Context for the given file_path
+            # This will be used by shotgun.pyp to ensure the correct
+            # context is set when the c4d document is changed.
+            engine.set_document_context(file_path, context)
+
         if operation == "current_path":
-            # return the current scene path
             return doc[c4d.DOCUMENT_FILEPATH]
         elif operation == "open":
             c4d.documents.LoadFile(file_path)

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -16,7 +16,7 @@ import tank
 menu_prebuild = [   ['File Save...', '1825592'],
                     ['File Open...', '1760964'],
                     ['Snapshot...', '2436236'],
-                    ['Jump to Shotgun', '2701393'], 
+                    ['Jump to Shotgun', '2701393'],
                     ['Jump to File System', '2158662'],
                     ['Jump to Screening Room in RV', '2188709'],
                     ['Jump to Screening Room Web Player', '2419038'],
@@ -103,7 +103,7 @@ class callbackPlugin(c4d.plugins.CommandData):
         for item in engine.commands.items():
             if self.callback in item[0]:
                 item[1].get('callback').__call__()
-        
+
         if self.callback == 'Jump to File System':
             self._jump_to_fs()
         elif self.callback == 'Jump to Shotgun':
@@ -123,11 +123,8 @@ class SceneChangeEvent(c4d.plugins.MessageData):
                 if "Untitled " not in new_document:
                     self.document = new_document
                     try:
-                        current_engine = tank.platform.current_engine()
-                        tk = tank.tank_from_path(self.document)
-                        logger.debug("Extracted sgtk instance: '%r' from path: '%r'", tk, self.document)
-                        ctx = tk.context_from_path(self.document)
-                        current_engine.change_context(ctx)
+                        ctx = engine.get_document_context(self.document)
+                        engine.change_context(ctx)
                     except tank.TankError, e:
                         logger.exception("Could not execute tank_from_path('%s')" % self.document)
         return True
@@ -163,7 +160,7 @@ def PluginMessage(id, data):
 def register_plugins():
 
     c4d.plugins.RegisterMessagePlugin(id=15151510, str="", info=0, dat=SceneChangeEvent())
-    
+
     for item in engine.import_module("tk_cinema").constant_apps.menu_prebuild:
         if not "separator" in item[-1]:
             c4d.plugins.RegisterCommandPlugin(


### PR DESCRIPTION
Hello hello,

I ran into an issue where tk-cinema was not setting the full shotgun context. My shotgun config templates are a bit different than the standard templates and therefore the context_from_path method was yielding an incomplete context without the Pipeline Step or Task set. 

This PR adds two methods `get_document_context` and `set_document_context` to the tk-cinema Engine class. `set_document_context` is called in the scene_operation_tk-cinema hook to store the full context for a file path. Then in shotgun.pyp `get_document_context` is called to retrieve the full context in the SceneChangeEvent hook. If a context is not found for the given file path, `get_document_context` falls back to context_from_path ensuring that some context is set regardless.