### PR TITLE
fixed double files on saving and save dialog on exit

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -360,8 +360,11 @@ def _save_session(path):
     ensure_folder_exists(folder)
 
     doc = c4d.documents.GetActiveDocument()
-    c4d.documents.SaveDocument(doc, str(path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-    c4d.documents.LoadFile(path)
+
+	split = path.split("\\")
+	doc.SetDocumentName(split[-1])
+	doc.SetDocumentPath("\\".join(split[:-1]))
+	c4d.documents.SaveDocument(doc, str(path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
 
 
 # TODO: method duplicated in all the cinema hooks

--- a/hooks/tk-multi-publish2/basic/start_version_control.py
+++ b/hooks/tk-multi-publish2/basic/start_version_control.py
@@ -305,8 +305,11 @@ def _save_session(path):
     ensure_folder_exists(folder)
 
     doc = c4d.documents.GetActiveDocument()
-    c4d.documents.SaveDocument(doc, str(path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-    c4d.documents.LoadFile(path)
+
+	split = path.split("\\")
+	doc.SetDocumentName(split[-1])
+	doc.SetDocumentPath("\\".join(split[:-1]))
+	c4d.documents.SaveDocument(doc, str(path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
 
 
 # TODO: method duplicated in all the cinema hooks

--- a/hooks/tk-multi-snapshot/scene_operation_tk-cinema.py
+++ b/hooks/tk-multi-snapshot/scene_operation_tk-cinema.py
@@ -51,5 +51,8 @@ class SceneOperation(Hook):
             c4d.documents.LoadFile(file_path)
         elif operation == "save":
             current_project = doc[c4d.DOCUMENT_FILEPATH]
-            c4d.documents.SaveDocument(doc, str(current_project), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-            c4d.documents.LoadFile(current_project)
+
+			split = file_path.split("\\")
+			doc.SetDocumentName(split[-1])
+			doc.SetDocumentPath("\\".join(split[:-1]))
+			c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
@@ -96,10 +96,14 @@ class SceneOperation(HookClass):
         elif operation == "open":
             c4d.documents.LoadFile(file_path)
         elif operation == "save":
-            c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-            c4d.documents.LoadFile(file_path)
+			split = file_path.split("\\")
+			doc.SetDocumentName(split[-1])
+			doc.SetDocumentPath("\\".join(split[:-1]))
+			c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
         elif operation == "save_as":
-            c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-            c4d.documents.LoadFile(file_path)
+			split = file_path.split("\\")
+			doc.SetDocumentName(split[-1])
+			doc.SetDocumentPath("\\".join(split[:-1]))
+			c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
         elif operation == "reset":
             return True

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -168,7 +168,7 @@ def EnhanceMainMenu():
 def PluginMessage(id, data):
     if id==c4d.C4DPL_BUILDMENU:
         EnhanceMainMenu()
-    if id==c4d.C4DPL_ENDPROGRAM:
+    if id==c4d.C4DPL_ENDACTIVITY:
         # Close Cinema Solution after PySide executes
         os.kill(os.getpid(), signal.SIGTERM)
 


### PR DESCRIPTION
Hi!

This is my first time doing a pull request on someone elses repo, I hope I am doing this right.

I am currently implementing tk-cinema4d and I found two fixes that make life a little easier in Cinema.

The two issues that I found was
1. When saving a document the old document would stay open because of the save/load calls.  By setting the name and path of the document and then saving you get the correct setup without duplicate files. (Not sure which of the save calls are used here, so I just edited all of them)
2. When exiting Cinema 4D the `os.kill()` call would immediately close the Application with no regards to unsaved documents. By calling `os.kill()` not in the `C4DPL_ENDPROGRAM` message, but the `C4DPL_ENDACTIVITY` message Cinema has time to ask, if the unsaved scenes should be saved and only terminates the application after all of that is done.

Thanks for your great work of porting the toolkit, it is very useful!