### PR TITLE
General improvements and patches.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -686,9 +686,9 @@ class CinemaEngine(Engine):
 
         self._init_shotgun_cache()
 
-        doc_path = doc_path.replace('\\', '/').lower()
-        if doc_path in c4d._shotgun_cache['DOCUMENT_CONTEXT_MAP']:
-            return c4d._shotgun_cache['DOCUMENT_CONTEXT_MAP'][doc_path]
+        cache_key = doc_path.replace('\\', '/').lower()
+        if cache_key in c4d._shotgun_cache['DOCUMENT_CONTEXT_MAP']:
+            return c4d._shotgun_cache['DOCUMENT_CONTEXT_MAP'][cache_key]
         else:
             return self.sgtk.context_from_path(doc_path)
 
@@ -697,5 +697,5 @@ class CinemaEngine(Engine):
 
         self._init_shotgun_cache()
 
-        doc_path = doc_path.replace('\\', '/').lower()
-        c4d._shotgun_cache['DOCUMENT_CONTEXT_MAP'][doc_path] = context
+        cache_key = doc_path.replace('\\', '/').lower()
+        c4d._shotgun_cache['DOCUMENT_CONTEXT_MAP'][cache_key] = context

--- a/hooks/tk-multi-loader2/tk-cinema_actions.py
+++ b/hooks/tk-multi-loader2/tk-cinema_actions.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Hook that loads defines all the available actions, broken down by publish type. 
+Hook that loads defines all the available actions, broken down by publish type.
 """
 
 import os
@@ -61,9 +61,9 @@ class CinemaActions(HookBaseClass):
         - If it will be shown in the details area, "details" is passed.
         - If it will be shown in the history area, "history" is passed.
 
-        Please note that it is perfectly possible to create more than one 
+        Please note that it is perfectly possible to create more than one
         action "instance" for an action!
-        You can for example do scene introspectionvif the action passed in 
+        You can for example do scene introspectionvif the action passed in
         is "character_attachment" you may for examplevscan the scene, figure
         out all the nodes where this object can bevattached and return a list
         of action instances: "attach to left hand",v"attach to right hand" etc.
@@ -71,11 +71,11 @@ class CinemaActions(HookBaseClass):
         the params key to pass additional data into the run_action hook.
 
         :param sg_publish_data: Shotgun data dictionary with all the standard
-                                publish fields. 
+                                publish fields.
         :param actions: List of action strings which have been
-                        defined in the app configuration. 
+                        defined in the app configuration.
         :param ui_area: String denoting the UI Area (see above).
-        :returns List of dictionaries, each with keys name, params, caption 
+        :returns List of dictionaries, each with keys name, params, caption
          and description
         """
 
@@ -144,7 +144,7 @@ class CinemaActions(HookBaseClass):
             params: Parameters passed down from the generate_actions hook.
 
         .. note::
-            This is the default entry point for the hook. It reuses the 
+            This is the default entry point for the hook. It reuses the
             ``execute_action`` method for backward compatibility with hooks
              written for the previous version of the loader.
 
@@ -167,7 +167,7 @@ class CinemaActions(HookBaseClass):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.
-        
+
         :param name: Action name string representing one of the items returned
                      by generate_actions.
         :param params: Params data, as specified by generate_actions.
@@ -204,7 +204,7 @@ class CinemaActions(HookBaseClass):
         """
         Create a reference with the same settings Cinema would use
         if you used the create settings dialog.
-        
+
         :param path: Path to file.
         :param sg_publish_data: Shotgun data dictionary with all the standard
                                 publish fields.
@@ -214,9 +214,9 @@ class CinemaActions(HookBaseClass):
 
         namespace = "%s %s" % (sg_publish_data.get("entity").get("name"), sg_publish_data.get("name"))
         namespace = namespace.replace(" ", "_")
-        
+
         doc = c4d.documents.GetActiveDocument()
-        
+
         xref = c4d.BaseObject(c4d.Oxref)
         doc.InsertObject(xref)
         xref.SetParameter(c4d.ID_CA_XREF_FILE, path, c4d.DESCFLAGS_SET_USERINTERACTION)
@@ -228,28 +228,34 @@ class CinemaActions(HookBaseClass):
         """
         Create a reference with the same settings Cinema would use
         if you used the create settings dialog.
-        
+
         :param path: Path to file.
         :param sg_publish_data: Shotgun data dictionary with all the standard
                                 publish fields.
         """
         doc = c4d.documents.GetActiveDocument()
-        
+
         if not os.path.exists(path):
             raise TankError("File not found on disk - '%s'" % path)
 
-        import_project_extensions = (".c4d")
-
+        import_project_extensions = (".c4d",)
         _, extension = os.path.splitext(path)
-
         if extension.lower() in import_project_extensions:
-            c4d.documents.MergeDocument(doc, path, 0)
+            c4d.documents.MergeDocument(
+                doc,
+                path,
+                (
+                    c4d.SCENEFILTER_OBJECTS |
+                    c4d.SCENEFILTER_MATERIALS |
+                    c4d.SCENEFILTER_MERGESCENE
+                ),
+            )
             c4d.EventAdd()
 
     def _create_texture_node(self, path, sg_publish_data):
         """
         Create a file texture node for a texture
-        
+
         :param path:             Path to file.
         :param sg_publish_data:  Shotgun data dictionary with all the standard
                                  publish fields.
@@ -257,10 +263,10 @@ class CinemaActions(HookBaseClass):
         """
 
         doc = c4d.documents.GetActiveDocument()
-        
+
         file_node = c4d.BaseList2D(c4d.Xbitmap)
         file_node[c4d.BITMAPSHADER_FILENAME] = path
         doc.InsertShader(file_node)
         c4d.EventAdd()
-        
+
         return file_node

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -356,15 +356,14 @@ def _save_session(path):
     """
 
     # Ensure that the folder is created when saving
-    folder = os.path.dirname(path)
+    folder, file = os.path.split(path)
     ensure_folder_exists(folder)
 
     doc = c4d.documents.GetActiveDocument()
 
-	split = path.split("\\")
-	doc.SetDocumentName(split[-1])
-	doc.SetDocumentPath("\\".join(split[:-1]))
-	c4d.documents.SaveDocument(doc, str(path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
+    doc.SetDocumentName(file)
+    doc.SetDocumentPath(folder)
+    c4d.documents.SaveDocument(doc, path, c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
 
 
 # TODO: method duplicated in all the cinema hooks

--- a/hooks/tk-multi-publish2/basic/start_version_control.py
+++ b/hooks/tk-multi-publish2/basic/start_version_control.py
@@ -301,15 +301,14 @@ def _save_session(path):
     """
 
     # Ensure that the folder is created when saving
-    folder = os.path.dirname(path)
+    folder, file = os.path.split(path)
     ensure_folder_exists(folder)
 
     doc = c4d.documents.GetActiveDocument()
 
-	split = path.split("\\")
-	doc.SetDocumentName(split[-1])
-	doc.SetDocumentPath("\\".join(split[:-1]))
-	c4d.documents.SaveDocument(doc, str(path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
+    doc.SetDocumentName(file)
+    doc.SetDocumentPath(folder)
+    c4d.documents.SaveDocument(doc, path, c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
 
 
 # TODO: method duplicated in all the cinema hooks

--- a/hooks/tk-multi-snapshot/scene_operation_tk-cinema.py
+++ b/hooks/tk-multi-snapshot/scene_operation_tk-cinema.py
@@ -52,7 +52,7 @@ class SceneOperation(Hook):
         elif operation == "save":
             current_project = doc[c4d.DOCUMENT_FILEPATH]
 
-			split = file_path.split("\\")
-			doc.SetDocumentName(split[-1])
-			doc.SetDocumentPath("\\".join(split[:-1]))
-			c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
+            folder, file = os.path.split(file_path)
+            doc.SetDocumentName(file)
+            doc.SetDocumentPath(folder)
+            c4d.documents.SaveDocument(doc, file_path, c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
@@ -95,12 +95,11 @@ class SceneOperation(HookClass):
             return doc[c4d.DOCUMENT_FILEPATH]
         elif operation == "open":
             c4d.documents.LoadFile(file_path)
-        elif operation == "save":
-			split = file_path.split("\\")
-			doc.SetDocumentName(split[-1])
-			doc.SetDocumentPath("\\".join(split[:-1]))
-			c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-        elif operation == "save_as":
+        elif operation in ("save", "save_as"):
+            folder, file = os.path.split(file_path)
+            doc.SetDocumentName(file)
+            doc.SetDocumentPath(folder)
+            c4d.documents.SaveDocument(doc, file_path, c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
 			split = file_path.split("\\")
 			doc.SetDocumentName(split[-1])
 			doc.SetDocumentPath("\\".join(split[:-1]))

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-cinema.py
@@ -85,7 +85,7 @@ class SceneOperation(HookClass):
 
         doc = c4d.documents.GetActiveDocument()
 
-        if operation in ['open', 'save', 'save_as']:
+        if operation in ('open', 'save', 'save_as'):
             # Store the full Shotgun Context for the given file_path
             # This will be used by shotgun.pyp to ensure the correct
             # context is set when the c4d document is changed.
@@ -100,9 +100,30 @@ class SceneOperation(HookClass):
             doc.SetDocumentName(file)
             doc.SetDocumentPath(folder)
             c4d.documents.SaveDocument(doc, file_path, c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
-			split = file_path.split("\\")
-			doc.SetDocumentName(split[-1])
-			doc.SetDocumentPath("\\".join(split[:-1]))
-			c4d.documents.SaveDocument(doc, str(file_path), c4d.SAVEDOCUMENTFLAGS_NONE, c4d.FORMAT_C4DEXPORT)
         elif operation == "reset":
+            if doc.GetChanged():
+                response = c4d.gui.QuestionDialog(
+                    'The active document has unsaved changes.\n'
+                    'Would you like to save?'
+                )
+                if response:
+                    active_name = doc.GetDocumentName()
+                    active_path = doc.GetDocumentPath()
+                    active_file_path = os.path.join(active_path, active_name)
+                    c4d.documents.SaveDocument(
+                        doc,
+                        active_file_path or '',
+                        (
+                            c4d.SAVEDOCUMENTFLAGS_SAVEAS,
+                            c4d.SAVEDOCUMENTFLAGS_NONE
+                        )[bool(active_file_path)],
+                        c4d.FORMAT_C4DEXPORT,
+                    )
+
+            new_doc = c4d.documents.BaseDocument()
+            c4d.documents.InsertBaseDocument(new_doc)
+            c4d.documents.SetActiveDocument(new_doc)
+
+            # Store full Shotgun Context context for new untitled document.
+            engine.set_document_context(new_doc[c4d.DOCUMENT_FILEPATH], context)
             return True

--- a/startup.py
+++ b/startup.py
@@ -80,7 +80,8 @@ class CinemaLauncher(SoftwareLauncher):
             "PYTHONPATH", os.path.join(startup_path, 'libs')
         )
         required_env["PYTHONPATH"] = os.environ["PYTHONPATH"]
-        required_env["C4DPYTHONPATH37"] = os.environ["PYTHONPATH"]
+        required_env["C4DPYTHONPATH37"] = os.environ["PYTHONPATH"]  # R23
+        required_env["C4DPYTHONPATH39"] = os.environ["PYTHONPATH"]  # R24
 
         # Prepare the launch environment with variables required by the
         # classic bootstrap approach.

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -135,13 +135,24 @@ class SceneChangeEvent(c4d.plugins.MessageData):
         if id == c4d.EVMSG_CHANGE:
             new_document = c4d.documents.GetActiveDocument()[c4d.DOCUMENT_FILEPATH]
             if new_document != self.document:
-                if "Untitled " not in new_document:
-                    self.document = new_document
-                    try:
-                        ctx = engine.get_document_context(self.document)
-                        engine.change_context(ctx)
-                    except tank.TankError as e:
-                        logger.exception("Could not execute tank_from_path('%s')" % self.document)
+                self.document = new_document
+
+                try:
+                    ctx = engine.get_document_context(self.document)
+                except Exception as e:
+                    logger.debug((
+                        'Could not determine context from "%s"'
+                    )% (self.document, str(e)))
+                    return True
+
+                try:
+                    engine.change_context(ctx)
+                except Exception as e:
+                    logger.debug((
+                        'Could not set context for "%s"\n'
+                        'context: %s\n'
+                        'error: %s\n'
+                    ) % (self.document, ctx, str(e)))
         return True
 
 

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -40,7 +40,7 @@ menu_prebuild = [
     ['Snapshot History...', '3313077'],
 ]
 
-logger = sgtk.LogManager.get_logger(__name__)
+logger = sgtk.LogManager.get_logger('shotgun.pyp')
 logger.debug("Launching toolkit in classic mode.")
 env_engine = os.environ.get("SGTK_ENGINE")
 env_context = os.environ.get("SGTK_CONTEXT")


### PR DESCRIPTION
This PR continues improvements made in @MaxZachner 's PR #10. I made his changes cross-platform by using os.path.split rather than .split('\\'). I also changed tabs in his changes to spaces.

I also added support for the `reset` operation which is called when `New File` is pressed in the lower left corner of the workfiles dialog. This will now create a new Untitled document and store the associated context from the workfiles dialog. When you finally go to save that document, it will open the Save As dialog in the correct context.

Finally this PR adds support for Cinema4d S24 but in order for PySide2 to work I had to build it for the correct version of CPython39 and msvc. That work was done awhile ago but I forgot to make a PR. You can get the prebuilt PySide2 and shiboken2 binaries for S24 here https://github.com/danbradham/wheels. In order to use them you'll have to either install them using pip with c4dpy or extract them to a shared network location and add that path to PYTHONPATH when launching cinema4D.