### PR TITLE
Add support for Cinema4D 2023 with new version schema.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -382,10 +382,10 @@ class CinemaEngine(Engine):
             qt_app = QtGui.QApplication([])
             qt_app.setWindowIcon(QtGui.QIcon(self.icon_256))
             qt_app.setQuitOnLastWindowClosed(False)
-
-            # set up the dark style
-            self._initialize_dark_look_and_feel()
             qt_app.aboutToQuit.connect(qt_app.deleteLater)
+
+        # set up the dark style
+        self._initialize_dark_look_and_feel()
 
     def post_app_init(self):
         """

--- a/startup.py
+++ b/startup.py
@@ -20,7 +20,7 @@ class CinemaLauncher(SoftwareLauncher):
     # matching against supplied versions and products. Similar to the glob
     # strings, these allow us to alter the regex matching for any of the
     # variable components of the path in one place
-    COMPONENT_REGEX_LOOKUP = {"version": r"R\d\d"}
+    COMPONENT_REGEX_LOOKUP = {"version": r"R\d\d|\d\d\d\d"}
 
     EXECUTABLE_TEMPLATES = {
         "darwin": [


### PR DESCRIPTION
A minor tweak to the version regex to support Cinema4D's new yearly versioning schema.

One more tweak is applied here that ensures the SG QPalette is applied even if a QApp already exists. In my studio I have a couple of other Qt tools running in Cinema4D and if one of those is started before the cinema engine, the stylesheet would not be applied.